### PR TITLE
Fixed an error that did not work on a page with only the Print button

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -109,7 +109,7 @@ const main = () => {
         }
 
         const textNode = [...btn.childNodes].find((x) => {
-            return x.textContent.includes("Download")
+            return x.textContent.includes("Download") || x.textContent.includes("Print")
         })
         textNode.textContent = `Download ${name}`
 


### PR DESCRIPTION
It doesn't work on this [page](https://musescore.com/classicman/scores/157928)
![image](https://user-images.githubusercontent.com/20399222/77848389-49624e80-71ff-11ea-9897-f91040fe84a2.png)
The button containing the Print text has also been changed to select.
![image](https://user-images.githubusercontent.com/20399222/77848410-672fb380-71ff-11ea-963f-c4c6e20a66a2.png)
On pages with both Download and Print buttons, the button with Download is selected first, which ensures normal operation.
![image](https://user-images.githubusercontent.com/20399222/77848440-93e3cb00-71ff-11ea-9b4e-056ba0c05f4a.png)
