### PR TITLE
feat: add check for latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "musescore-downloader",
-  "version": "0.23.4",
+  "version": "0.23.5",
   "description": "download sheet music from musescore.com for free, no login or Musescore Pro required | 免登录、免 Musescore Pro，免费下载 musescore.com 上的曲谱",
   "main": "dist/main.js",
   "bin": "dist/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -186,7 +186,11 @@ void (async () => {
   )
   spinner.succeed('OK')
 
-  if (!(await isNpx()) && !(await isLatest())) {
-    console.log(chalk.yellowBright(`Your installed version (${await installedVersion()}) of the musescore-downloader CLI is not the latest one (${await latestVersion()})!\nRun npm i -g musescore-downloader to update.`))
+  if (!(await isNpx())) {
+    const installed = await installedVersion()
+    const latest = await latestVersion()
+    if (!isLatest(installed, latest)) {
+      console.log(chalk.yellowBright(`Your installed version (${installed}) of the musescore-downloader CLI is not the latest one (${latest})!\nRun npm i -g musescore-downloader to update.`))
+    }
   }
 })()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { loadMscore, INDV_DOWNLOADS, WebMscore } from './mscore'
 import { ScoreInfo, ScoreInfoHtml, ScoreInfoObj, getActualId } from './scoreinfo'
 import { getLibreScoreLink } from './librescore-link'
 import { escapeFilename } from './utils'
+import { isNpx, isLatest, installedVersion, latestVersion } from './npm-data'
 import i18n from './i18n'
 
 const inquirer: typeof import('inquirer') = require('inquirer')
@@ -184,4 +185,8 @@ void (async () => {
     }),
   )
   spinner.succeed('OK')
+
+  if (!(await isNpx()) && !(await isLatest())) {
+    console.log(chalk.yellowBright(`Your installed version (${await installedVersion()}) of the musescore-downloader CLI is not the latest one (${await latestVersion()})!\nRun npm i -g musescore-downloader to update.`))
+  }
 })()

--- a/src/npm-data.ts
+++ b/src/npm-data.ts
@@ -1,0 +1,16 @@
+import { exec as _exec } from 'child_process';
+import { promisify } from 'util';
+
+const exec = promisify(_exec);
+
+export async function isNpx() {
+	const output = await exec('npm list -g musescore-downloader')
+	return output.stdout.includes('(empty)');
+}
+
+export async function isLatest() {
+	const version = (/musescore-downloader@([\d\.]+)/).exec((await exec('npm list -g musescore-downloader')).stdout)![1]
+	const latest = (await exec('npm info musescore-downloader version')).stdout.trim()
+
+	return version.trim() === latest
+}

--- a/src/npm-data.ts
+++ b/src/npm-data.ts
@@ -8,9 +8,14 @@ export async function isNpx() {
   return output.stdout.includes('(empty)');
 }
 
-export async function isLatest() {
-  const version = (/musescore-downloader@([\d\.]+)/).exec((await exec('npm list -g musescore-downloader')).stdout)![1]
-  const latest = (await exec('npm info musescore-downloader version')).stdout.trim()
+export async function installedVersion() {
+  return (/musescore-downloader@([\d\.]+)/).exec((await exec('npm list -g musescore-downloader')).stdout)![1].trim()
+}
 
-  return version.trim() === latest
+export async function latestVersion() {
+  return (await exec('npm info musescore-downloader version')).stdout.trim()
+}
+
+export async function isLatest() {
+  return await installedVersion() === await latestVersion()
 }

--- a/src/npm-data.ts
+++ b/src/npm-data.ts
@@ -9,7 +9,7 @@ export async function isNpx() {
 }
 
 export async function installedVersion() {
-  return (/musescore-downloader@([\d\.]+)/).exec((await exec('npm list -g musescore-downloader')).stdout)![1].trim()
+  return require('../package.json').version
 }
 
 export async function latestVersion() {

--- a/src/npm-data.ts
+++ b/src/npm-data.ts
@@ -4,13 +4,13 @@ import { promisify } from 'util';
 const exec = promisify(_exec);
 
 export async function isNpx() {
-	const output = await exec('npm list -g musescore-downloader')
-	return output.stdout.includes('(empty)');
+  const output = await exec('npm list -g musescore-downloader')
+  return output.stdout.includes('(empty)');
 }
 
 export async function isLatest() {
-	const version = (/musescore-downloader@([\d\.]+)/).exec((await exec('npm list -g musescore-downloader')).stdout)![1]
-	const latest = (await exec('npm info musescore-downloader version')).stdout.trim()
+  const version = (/musescore-downloader@([\d\.]+)/).exec((await exec('npm list -g musescore-downloader')).stdout)![1]
+  const latest = (await exec('npm info musescore-downloader version')).stdout.trim()
 
-	return version.trim() === latest
+  return version.trim() === latest
 }

--- a/src/npm-data.ts
+++ b/src/npm-data.ts
@@ -1,11 +1,11 @@
-import { exec as _exec } from 'child_process';
-import { promisify } from 'util';
+import { exec as _exec } from 'child_process'
+import { promisify } from 'util'
 
-const exec = promisify(_exec);
+const exec = promisify(_exec)
 
 export async function isNpx() {
   const output = await exec('npm list -g musescore-downloader')
-  return output.stdout.includes('(empty)');
+  return output.stdout.includes('(empty)')
 }
 
 export async function installedVersion() {


### PR DESCRIPTION
if you're running msdl via `npm i -g musescore-downloader` instead of `npx`, checks if the latest version is installed.

couldn't really test it obviously but seems to be logically working