### PR TITLE
fix: rename discord channel from dataset-bugs to dataset-patcher

### DIFF
--- a/src/btn.ts
+++ b/src/btn.ts
@@ -291,7 +291,7 @@ export namespace BtnAction {
           // ask user to send Discord message
           alert(
             '❌Download Failed!\n\n' +
-            'Send your URL to the #dataset-bugs channel ' +
+            'Send your URL to the #dataset-patcher channel ' +
             'in the LibreScore Community Discord server:\n' + DISCORD_URL,
           )
           // open Discord on 'OK'


### PR DESCRIPTION
Raname the channel so that people don't confuse bug-reports with dataset-bugs.